### PR TITLE
More robust is_mounted() method and mount_point configuration.

### DIFF
--- a/jss/distribution_points.py
+++ b/jss/distribution_points.py
@@ -112,7 +112,7 @@ class DistributionPoints(object):
                             password = repo.get('password')
 
                             mount_point = os.path.join('/Volumes', share_name)
-
+                        
                             if connection_type == 'AFP':
                                 dp = AFPDistributionPoint(URL=URL, port=port,
                                     share_name=share_name,
@@ -370,6 +370,15 @@ class MountedRepository(Repository):
 
         """
 
+        # Initially check to see if mounted path exists for the currently defined
+        # mount_point. This will catch situations where different servers, 
+        # have the same share name. If the actual mount is detected later on in
+        # this method it will reset it to the appropriate 'mount_point'
+        count = 1
+        while os.path.ismount(self.connection['mount_point']):
+            self.connection['mount_point'] = "%s-%s" % (self.connection['mount_point'], count)
+            count += 1
+
         if isinstance(self, AFPDistributionPoint):
             fs_type = "afpfs"
         elif isinstance(self, SMBDistributionPoint):
@@ -379,24 +388,42 @@ class MountedRepository(Repository):
 
         share_name = self.connection['share_name']
         check_url = self.connection['URL']
-        
+        check_port = self.connection['port']
+
         mount_check = subprocess.check_output('mount').splitlines()
+
         # The mount command returns lines like this
         # //username@pretendco.com/JSS%20REPO on /Volumes/JSS REPO (afpfs, nodev, nosuid, mounted by local_me)
 
         for mount in mount_check:
-            # This will check if the share is mounted using a name other than the share_name.
-            mount_string = os.path.join(check_url, urllib.quote(share_name, safe='~()*!.\''))
+            import socket
 
-            if mount_string in mount and fs_type in mount:
-                print "%s is already mounted." % mount_string
+            # This will check if the share is mounted using a name other than the share_name.
+            ip_address = socket.gethostbyname(check_url)
+            quoted_share = urllib.quote(share_name, safe='~()*!.\'')
+            
+            ip_url = os.path.join(ip_address, quoted_share)
+            ip_url_with_port = os.path.join('%s:%s' % (ip_address, check_port), quoted_share)
+            any_match = (ip_url, ip_url_with_port)
+
+            #fqdn may or may not be resolvable so check it here.
+            fqdn = socket.getfqdn(ip_address)
+            if fqdn:
+                fqdn_url = os.path.join(fqdn, quoted_share)
+                fqdn_url_with_port = os.path.join('%s:%s' % (fqdn, check_port), quoted_share)
+                any_match = any_match + (fqdn_url, fqdn_url_with_port,)
+
+            if any(match in mount for match in any_match) \
+                and fs_type in mount.rsplit('(')[-1].split(',')[0]:
+                
+                print "%s is already mounted.\n" % fqdn_url
                 self._was_mounted = True
                 # Get the string between "on" and the "(" symbol, then strip front and back.
-                mount_point = mount.split('on ')[1].split('(')[0].lstrip().rstrip()                
+                mount_point = mount.split(' on ')[1].split('(')[0].strip()                
 
                 # Reset the connection's mount point to the discovered value.
                 if mount_point:
-                    print 'Using "%s" as the mount_point' % mount_point
+                    print 'Using "%s" as the mount_point\n' % mount_point
                     self.connection['mount_point'] = mount_point
 
         # Do an inexpensive double check...

--- a/jss/distribution_points.py
+++ b/jss/distribution_points.py
@@ -315,6 +315,7 @@ class MountedRepository(Repository):
     """Parent class for mountable file shares."""
     def __init__(self, **connection_args):
         super(MountedRepository, self).__init__(**connection_args)
+        self._was_mounted = False
 
     def _build_url(self):
         pass
@@ -344,12 +345,16 @@ class MountedRepository(Repository):
     def umount(self):
         """Try to unmount our mount point."""
         # If not mounted, don't bother.
+        
         if os.path.exists(self.connection['mount_point']):
+            if self._was_mounted:
+                print "Distribution point was previously mounted, will not unmount"
+                
             # Force an unmount. If you are manually mounting and
             # unmounting shares with python, chances are good that you
             # know what you are doing and *want* it to unmount. For
             # real.
-            if sys.platform == 'darwin':
+            elif sys.platform == 'darwin':
                 subprocess.check_call(['/usr/sbin/diskutil', 'unmount',
                                        'force',
                                        self.connection['mount_point']])
@@ -385,7 +390,7 @@ class MountedRepository(Repository):
 
             if mount_string in mount and fs_type in mount:
                 print "%s is already mounted." % mount_string
-                
+                self._was_mounted = True
                 # Get the string between "on" and the "(" symbol, then strip front and back.
                 mount_point = mount.split('on ')[1].split('(')[0].lstrip().rstrip()                
 

--- a/jss/distribution_points.py
+++ b/jss/distribution_points.py
@@ -366,31 +366,33 @@ class MountedRepository(Repository):
         """
 
         if isinstance(self, AFPDistributionPoint):
-            _connection_type = "afpfs"
+            fs_type = "afpfs"
         elif isinstance(self, SMBDistributionPoint):
-            _connection_type = "smbfs"
+            fs_type = "smbfs"
         else:
-            _connection_type = "undefined"
+            fs_type = "undefined"
 
-        _share_name = self.connection['share_name']
-        _check_url = self.connection['URL']
+        share_name = self.connection['share_name']
+        check_url = self.connection['URL']
         
         mount_check = subprocess.check_output('mount').splitlines()
         # The mount command returns lines like this
         # //username@pretendco.com/JSS%20REPO on /Volumes/JSS REPO (afpfs, nodev, nosuid, mounted by local_me)
 
-        for _mount in mount_check:
-            _mount_str = os.path.join(_check_url, urllib.quote(_share_name, safe='~()*!.\''))
-            if _mount_str in _mount and _connection_type in _mount:
-                print "%s is already mounted." % _mount_str
+        for mount in mount_check:
+            # This will check if the share is mounted using a name other than the share_name.
+            mount_string = os.path.join(check_url, urllib.quote(share_name, safe='~()*!.\''))
+
+            if mount_string in mount and fs_type in mount:
+                print "%s is already mounted." % mount_string
                 
                 # Get the string between "on" and the "(" symbol, then strip front and back.
-                _mount_point = _mount.split('on ')[1].split('(')[0].lstrip().rstrip()                
+                mount_point = mount.split('on ')[1].split('(')[0].lstrip().rstrip()                
 
                 # Reset the connection's mount point to the discovered value.
-                if _mount_point:
-                    print 'Using "%s" as the mount_point' % _mount_point
-                    self.connection['mount_point'] = _mount_point
+                if mount_point:
+                    print 'Using "%s" as the mount_point' % mount_point
+                    self.connection['mount_point'] = mount_point
 
         # Do an inexpensive double check...
         return os.path.ismount(self.connection['mount_point'])


### PR DESCRIPTION
We've been seeing a number of mount error -58 issues lately when trying to mount a DP.

What I think is happening is the DP is already mounted via CasperAdmin or by Finder. This PR directly addresses the issue by keeping the mount_point as a more common permutation of `/Volumes/ShareName` rather than prepending the DP's name key to the share_name key and removing spaces. 

This also takes it one step further and iterates over the results of `/sbin/mount` to determine if the share is already mounted and if so adjusts the "mount_point" to accurately reflect the current path.

There is potentially an issue where python-jss triggers an unmount while another application is accessing the share, but if that is the case unmount _should_ just silently fail, but that doesn't mean it will. I did have the thought of adding a instance variable like `_was_mounted` which could be set to `True` and then checked during `unmount`.

The other potential issue is the share was mounted as a different user than the currently specified one. I'm not sure exactly what to do with that. I just decided it made sense to let there be an IOError down the line if there is a permissions issue.

If there are any other questions you have or, reworking to this you think needs done, please let me know.

Thanks for the consideration,
-- Eldon