### PR TITLE
Add limitations functionality

### DIFF
--- a/jss/jss.py
+++ b/jss/jss.py
@@ -1611,6 +1611,25 @@ class Policy(JSSContainerObject):
         for section in clear_list:
             self.clear_list("%s%s" % ("scope/", section))
 
+    def add_object_to_limitations(self, obj):
+        """Add an object 'obj' to the appropriate scope limitations
+        block.
+
+        obj should be an instance of User, UserGroup, NetworkSegment,
+        or IBeacon.
+
+        """
+        if isinstance(obj, User):
+            self.add_object_to_path(obj, "scope/limitations/users")
+        elif isinstance(obj, UserGroup):
+            self.add_object_to_path(obj, "scope/limitations/user_groups")
+        elif isinstance(obj, NetworkSegment):
+            self.add_object_to_path(obj, "scope/limitations/network_segment")
+        elif isinstance(obj, IBeacon):
+            self.add_object_to_path(obj, "scope/limitations/ibeacons")
+        else:
+            raise TypeError
+
     def add_object_to_exclusions(self, obj):
         """Add an object 'obj' to the appropriate scope exclusions
         block.

--- a/jss/jss.py
+++ b/jss/jss.py
@@ -1326,9 +1326,9 @@ class LDAPGroupsResults(JSSContainerObject):
     can_delete = False
 
     def as_user_group(self, jss):
-        result = UserGroup(jss, self.find('ldap_group/groupname').text)
+        result = UserGroup(jss, self.findtext('ldap_group/groupname'))
         ElementTree.SubElement(result, 'id').text = \
-            self.find('ldap_group/uid').text
+            self.findtext('ldap_group/uid')
         return result
 
 class LicensedSoftware(JSSContainerObject):

--- a/jss/jss.py
+++ b/jss/jss.py
@@ -1544,6 +1544,15 @@ class Policy(JSSContainerObject):
                                                       "computer_groups")
         self.buildings = ElementTree.SubElement(self.scope, "buldings")
         self.departments = ElementTree.SubElement(self.scope, "departments")
+        self.limitations = ElementTree.SubElement(self.scope, "limitations")
+        self.limited_users = ElementTree.SubElement(self.limitations,
+                                                    "users")
+        self.limited_user_groups = ElementTree.SubElement(self.limitations,
+                                                          "user_groups")
+        self.limited_network_segments = ElementTree.SubElement(
+            self.limitations, "network_segments")
+        self.limited_ibeacons = ElementTree.SubElement(self.limitations,
+                                                       "ibeacons")
         self.exclusions = ElementTree.SubElement(self.scope, "exclusions")
         self.excluded_computers = ElementTree.SubElement(self.exclusions,
                                                          "computers")
@@ -1553,6 +1562,14 @@ class Policy(JSSContainerObject):
             self.exclusions, "buildings")
         self.excluded_departments = ElementTree.SubElement(self.exclusions,
                                                            "departments")
+        self.excluded_users = ElementTree.SubElement(self.exclusions,
+                                                    "users")
+        self.excluded_user_groups = ElementTree.SubElement(self.exclusions,
+                                                          "user_groups")
+        self.excluded_network_segments = ElementTree.SubElement(
+            self.exclusions, "network_segments")
+        self.excluded_ibeacons = ElementTree.SubElement(self.exclusions,
+                                                       "ibeacons")
 
         # Self Service
         self.self_service = ElementTree.SubElement(self, "self_service")

--- a/jss/jss.py
+++ b/jss/jss.py
@@ -1326,6 +1326,11 @@ class LDAPGroupsResults(JSSContainerObject):
     can_delete = False
 
     def as_user_group(self, jss):
+        """Maps uid to id and groupname to name, then returns a UserGroup type
+        object.
+
+        Useful for using an LDAPGroup in policy limitations and exclusions.
+        """
         result = UserGroup(jss, self.findtext('ldap_group/groupname'))
         ElementTree.SubElement(result, 'id').text = \
             self.findtext('ldap_group/uid')

--- a/jss/jss.py
+++ b/jss/jss.py
@@ -1325,6 +1325,11 @@ class LDAPGroupsResults(JSSContainerObject):
     can_put = False
     can_delete = False
 
+    def as_user_group(self, jss):
+        result = UserGroup(jss, self.find('ldap_group/groupname').text)
+        ElementTree.SubElement(result, 'id').text = \
+            self.find('ldap_group/uid').text
+        return result
 
 class LicensedSoftware(JSSContainerObject):
     _url = '/licensedsoftware'

--- a/jss/jss.py
+++ b/jss/jss.py
@@ -1336,6 +1336,17 @@ class LDAPGroupsResults(JSSContainerObject):
             self.findtext('ldap_group/uid')
         return result
 
+    def as_computer_group(self, jss):
+        """Maps uid to id and groupname to name, then returns a ComputerGroup
+        type object.
+
+        Useful for using an LDAPGroup in policy limitations and exclusions.
+        """
+        result = ComputerGroup(jss, self.findtext('ldap_group/groupname'))
+        ElementTree.SubElement(result, 'id').text = \
+            self.findtext('ldap_group/uid')
+        return result
+
 class LicensedSoftware(JSSContainerObject):
     _url = '/licensedsoftware'
 


### PR DESCRIPTION
This series of commits adds xml to policy scope xml and adds a wrapper method to add an object to the limitations of the scope.

In addition, a couple helper methods were added to help facilitate adding an ldap group as a limitation or exclusion.