### PR TITLE
Set all packages to install on reboot.

### DIFF
--- a/jss/jss.py
+++ b/jss/jss.py
@@ -1458,7 +1458,7 @@ class Package(JSSContainerObject):
         feu = ElementTree.SubElement(self, "fill_existing_users")
         feu.text = "false"
         boot_volume = ElementTree.SubElement(self, "boot_volume_required")
-        boot_volume.text = "false"
+        boot_volume.text = "true"
         allow_uninstalled = ElementTree.SubElement(self, "allow_uninstalled")
         allow_uninstalled.text = "false"
         ElementTree.SubElement(self, "os_requirements")


### PR DESCRIPTION
A minor modification to python-jss the sets all packages to Install on reboot, for those admins who use imaging as part of the software testing process.