### PR TITLE
convert xml_string to utf-8 instead of ascii

### DIFF
--- a/jss/jssobject.py
+++ b/jss/jssobject.py
@@ -477,7 +477,7 @@ class JSSObject(ElementTree.Element):
 
     @classmethod
     def from_string(cls, jss, xml_string):
-        """Creates a new JSSObject from an XML string.
+        """Creates a new JSSObject from an UTF-8 XML string.
 
         Args:
             jss: A JSS object.

--- a/jss/jssobject.py
+++ b/jss/jssobject.py
@@ -483,7 +483,7 @@ class JSSObject(ElementTree.Element):
             jss: A JSS object.
             xml_string: String XML file data used to create object.
         """
-        root = ElementTree.fromstring(xml_string)
+        root = ElementTree.fromstring(xml_string.encode('utf-8'))
         return cls(jss, root)
 
 


### PR DESCRIPTION
ElementTree.fromstring() will handle only str(), but xml_string is an unicode() so it gets automatically casted to 'ascii' - but 'utf-8' is better for so many reasons. fixes sheagcraig/JSSImporter#61