### PR TITLE
Fix an incompatibilty with kennethreitz/requests v2.11.1

### DIFF
--- a/jss/distribution_point.py
+++ b/jss/distribution_point.py
@@ -39,10 +39,10 @@ except ImportError:
 from .tools import (is_osx, is_linux, is_package)
 
 
-PKG_FILE_TYPE = 0
-EBOOK_FILE_TYPE = 1
-IN_HOUSE_APP_FILE_TYPE = 2
-SCRIPT_FILE_TYPE = 3
+PKG_FILE_TYPE = '0'
+EBOOK_FILE_TYPE = '1'
+IN_HOUSE_APP_FILE_TYPE = '2'
+SCRIPT_FILE_TYPE = '3'
 
 
 def auto_mounter(original):


### PR DESCRIPTION
When uploading a package to JCDS, I had the following error:
`Header value 0 must be of type str or bytes, not <type 'int'>`

This is due to kennethreitz/requests that now expect headers in string format.
Tested only on JCDS but shouldn't cause issue elsewhere.

https://github.com/kennethreitz/requests/commit/2669ab797ce769ecedf5493b04cb976f33e37210