### PR TITLE
Hotfix/curl headers

### DIFF
--- a/jss/curl_adapter.py
+++ b/jss/curl_adapter.py
@@ -71,7 +71,8 @@ class CurlAdapter(object):
         content_type = 'text/xml' if not files else 'multipart/form-data'
         header = ['Content-Type: {}'.format(content_type)]
         if headers:
-            header += headers
+            [header.append('{}: {}'.format(k, v)) for k, v in headers.iteritems()]
+            
         put_args = {"--request": "PUT"}
         return self._request(url, header, data, files, **put_args)
 
@@ -89,7 +90,7 @@ class CurlAdapter(object):
         # point of contact, so just do it here and keep it Unicode
         # everywhere else.
         command = [
-            item.encode('UTF-8') if isinstance(item, unicode) else str(item)
+            item.encode('UTF-8') if isinstance(item, unicode) else item
             for item in command]
 
         try:
@@ -143,7 +144,10 @@ class CurlAdapter(object):
             command += ['--header', header]
 
         if data:
-            command += ["--data", data]
+            if isinstance(data, file):
+                command += ["--data", "@{}".format(data.name)]
+            else:
+                command += ["--data", data]
 
         if files:
             path = files['name'][1].name

--- a/jss/curl_adapter.py
+++ b/jss/curl_adapter.py
@@ -90,7 +90,7 @@ class CurlAdapter(object):
         # point of contact, so just do it here and keep it Unicode
         # everywhere else.
         command = [
-            item.encode('UTF-8') if isinstance(item, unicode) else item
+            item.encode('UTF-8') if isinstance(item, unicode) else str(item)
             for item in command]
 
         try:

--- a/jss/curl_adapter.py
+++ b/jss/curl_adapter.py
@@ -62,7 +62,7 @@ class CurlAdapter(object):
         content_type = 'text/xml' if not files else 'multipart/form-data'
         header = ['Content-Type: {}'.format(content_type)]
         if headers:
-            header += headers
+            [header.append('{}: {}'.format(k, v)) for k, v in headers.iteritems()]
 
         post_kwargs = {"--request": "POST"}
         return self._request(url, header, data, files, **post_kwargs)
@@ -89,7 +89,7 @@ class CurlAdapter(object):
         # point of contact, so just do it here and keep it Unicode
         # everywhere else.
         command = [
-            item.encode('UTF-8') if isinstance(item, unicode) else item
+            item.encode('UTF-8') if isinstance(item, unicode) else str(item)
             for item in command]
 
         try:

--- a/jss/curl_adapter.py
+++ b/jss/curl_adapter.py
@@ -35,8 +35,34 @@ JSS object beginning with python-jss 2.0.0.
 
 import copy
 import subprocess
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler())
 
 from .exceptions import JSSError, SSLVerifyError
+
+CURL_RETURNCODE = {
+    1: 'Unsupported protocol. This build of curl has no support for this protocol.',
+    2: 'Failed to initialize.',
+    3: 'URL malformed. The syntax was not correct.',
+    4: 'A feature or option that was needed to perform the desired request was not enabled or was explicitly disabled '
+       'at build-time. To make curl able to do this, you probably need another build of libcurl!',
+    5: 'Couldn\'t resolve proxy. The given proxy host could not be resolved.',
+    6: 'Couldn\'t resolve host. The given remote host was not resolved.',
+    7: 'Failed to connect to host.',
+    8: 'Weird server reply. The server sent data curl couldn\'t parse.',
+    22: 'HTTP page not retrieved. The requested url was not found or returned another error with the HTTP error '
+        'code being 400 or above.',
+    23: 'Write error. Curl couldn\'t write data to a local filesystem or similar.',
+    27: 'Out of memory. A memory allocation request failed.',
+    28: 'Operation timeout. The specified time-out period was reached according to the conditions.',
+    33: 'HTTP range error. The range "command" didn\'t work.',
+    35: 'SSL connect error. The SSL handshaking failed.',
+    47: 'Too many redirects. When following redirects, curl hit the maximum amount.',
+    60: 'Peer certificate cannot be authenticated with known CA certificates.'
+}
 
 
 class CurlAdapter(object):
@@ -50,9 +76,9 @@ class CurlAdapter(object):
     """
     base_headers = ['Accept: application/xml']
 
-    def __init__(self):
+    def __init__(self, verify=True):
         self.auth = ('', '')
-        self.verify = True
+        self.verify = verify
         self.use_tls = True
 
     def get(self, url, headers=None):
@@ -90,17 +116,18 @@ class CurlAdapter(object):
         # point of contact, so just do it here and keep it Unicode
         # everywhere else.
         command = [
-            item.encode('UTF-8') if isinstance(item, unicode) else str(item)
+            item.encode('UTF-8') if isinstance(item, unicode) else item
             for item in command]
+
+        logger.debug(' '.join(command))
 
         try:
             response = subprocess.check_output(command)
         except subprocess.CalledProcessError as err:
-            if err.returncode == 60:
-                raise SSLVerifyError(
-                    'The JSS\'s certificate cannot be verified.')
+            if err.returncode in CURL_RETURNCODE:
+                raise JSSError('CURL Error: {}'.format(CURL_RETURNCODE[err.returncode]))
             else:
-                raise JSSError('Unknown curl error')
+                raise JSSError('Unknown curl error: {}'.format(err.returncode))
 
         return CurlResponseAdapter(response, url)
 
@@ -146,6 +173,8 @@ class CurlAdapter(object):
         if data:
             if isinstance(data, file):
                 command += ["--data", "@{}".format(data.name)]
+            elif isinstance(data, dict):
+                [command.extend(["-F", "{}={}".format(k, v)]) for k, v in data.iteritems()]
             else:
                 command += ["--data", data]
 


### PR DESCRIPTION
- Fixed the issue where a `file` object in the data dict was interpreted as a string.
- If a dict is given in `data`, it becomes form-urlencoded fields. JSON data may be supplied as a string or bytes.
- Debug logging has been added.
- curl return codes are looked up and a friendlier message is displayed.

NOTE: 
1. the debug logging can expose secrets
2. these commits were not tested in isolation (yet)

